### PR TITLE
Fixes a bug where secrets weren't exported properly (ES-1803)

### DIFF
--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -178,7 +178,6 @@ jobs:
       - persist_to_workspace:
           root: << parameters.output >>
           paths:
-            - secrets
             - '*'
 
 commands:

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -157,10 +157,13 @@ jobs:
             if [  << parameters.common-secrets >> = true ] ; then
 
               # Update secret file with common secrets
-              if [ "$HARPOCRATES_SECRETS" != "" ] ; then
-                yq e '.secrets += [ { env(HARPOCRATES_SECRETS): {"prefix": "K8S_CLUSTER_"}}]' -i << parameters.secret-file >>
+              if [ "$HARPOCRATES_SECRETS" != "" ]; then
+                IFS=',' read -ra SECRET_PATH <<<"$HARPOCRATES_SECRETS"
+                for i in "${SECRET_PATH[@]}"; do
+                  export TMP_PATHS="$i"
+                  yq e '.secrets += [ { env(TMP_PATHS): {"prefix": "K8S_CLUSTER_"}}]' -i  << parameters.secret-file >>
+                done
               fi
-
 
               if [ "$CLUSTER_SECRET" != "" ] ; then
                 yq e '.secrets += [ { env(CLUSTER_SECRET): {"prefix": "K8S_CLUSTER_", "format": "json", "fileName": "cluster_secret.json"}}]' -i << parameters.secret-file >>   

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -154,7 +154,7 @@ jobs:
             yq e '.output = env(OUTPUT)' -i  << parameters.secret-file >> 
 
             # Fetch common secrets 
-            if [  "<< parameters.common-secrets >>" == true ] ; then
+            if [  "<< parameters.common-secrets >>" = true ] ; then
 
               # Update secret file with common secrets
               if [ "$HARPOCRATES_SECRETS" != "" ] ; then

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -158,7 +158,7 @@ jobs:
 
               # Update secret file with common secrets
               if [ "$HARPOCRATES_SECRETS" != "" ]; then
-                IFS=',' read -ra SECRET_PATH <<<"$HARPOCRATES_SECRETS"
+                IFS=',' read -ra SECRET_PATH \<<<"$HARPOCRATES_SECRETS"
                 for i in "${SECRET_PATH[@]}"; do
                   export TMP_PATHS="$i"
                   yq e '.secrets += [ { env(TMP_PATHS): {"prefix": "K8S_CLUSTER_"}}]' -i  << parameters.secret-file >>

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -154,7 +154,7 @@ jobs:
             yq e '.output = env(OUTPUT)' -i  << parameters.secret-file >> 
 
             # Fetch common secrets 
-            if [  "<< parameters.common-secrets >>" = true ] ; then
+            if [  << parameters.common-secrets >> = true ] ; then
 
               # Update secret file with common secrets
               if [ "$HARPOCRATES_SECRETS" != "" ] ; then
@@ -170,7 +170,6 @@ jobs:
                 export TMP_PATH="ES/data/service_accounts/harbor/$SHORT-ci"
                 yq e '.secrets += [ { env(TMP_PATH): {"prefix": "DOCKER_"}}]' -i << parameters.secret-file >>
               fi
-
             fi
 
             /harpocrates \

--- a/vault/extractSecrets.go
+++ b/vault/extractSecrets.go
@@ -42,7 +42,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 				setUpper(d.UpperCase, &currentUpperCase)
 				setFormat(d.Format, &currentFormat)
 
-				if currentFormat != "" {
+				if len(d.Keys) == 0 {
 					secretValue, err := vaultClient.ReadSecret(fmt.Sprintf("%s", c))
 					if err != nil {
 						return nil, err

--- a/vault/extractSecrets.go
+++ b/vault/extractSecrets.go
@@ -40,8 +40,9 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 			for c, d := range aa {
 				setPrefix(d.Prefix, &currentPrefix)
 				setUpper(d.UpperCase, &currentUpperCase)
+				setFormat(d.Format, &currentFormat)
 
-				if d.Format != "" {
+				if currentFormat != "" {
 					secretValue, err := vaultClient.ReadSecret(fmt.Sprintf("%s", c))
 					if err != nil {
 						return nil, err

--- a/vault/extractSecrets.go
+++ b/vault/extractSecrets.go
@@ -23,6 +23,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 	var result = make(secrets.Result)
 	var currentPrefix = config.Config.Prefix
 	var currentUpperCase = config.Config.UpperCase
+	var currentFormat = config.Config.Format
 
 	for _, a := range input.Secrets {
 
@@ -39,8 +40,9 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 			for c, d := range aa {
 				setPrefix(d.Prefix, &currentPrefix)
 				setUpper(d.UpperCase, &currentUpperCase)
+				setFormat(d.Format, &currentFormat)
 
-				if d.Format != "" {
+				if currentFormat != "" {
 					secretValue, err := vaultClient.ReadSecret(fmt.Sprintf("%s", c))
 					if err != nil {
 						return nil, err
@@ -50,7 +52,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 						thisResult.Add(k, v, currentPrefix, currentUpperCase)
 					}
 
-					finalResult = append(finalResult, Outputs{Format: d.Format, Filename: d.FileName, Result: thisResult, Owner: d.Owner})
+					finalResult = append(finalResult, Outputs{Format: currentFormat, Filename: d.FileName, Result: thisResult, Owner: d.Owner})
 					continue
 				}
 
@@ -63,6 +65,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 						for h, i := range bb {
 							setPrefix(i.Prefix, &currentPrefix)
 							setUpper(d.UpperCase, &currentUpperCase)
+							setFormat(d.Format, &currentFormat)
 
 							if i.SaveAsFile != nil {
 								secretValue, err := vaultClient.ReadSecretKey(fmt.Sprintf("%s", c), h)
@@ -83,6 +86,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 							}
 							setPrefix(d.Prefix, &currentPrefix)
 							setUpper(d.UpperCase, &currentUpperCase)
+							setFormat(d.Format, &currentFormat)
 						}
 					} else {
 						secretValue, err := vaultClient.ReadSecretKey(fmt.Sprintf("%s", c), fmt.Sprintf("%s", f))
@@ -94,6 +98,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 				}
 				setPrefix(config.Config.Prefix, &currentPrefix)
 				setUpper(d.UpperCase, &currentUpperCase)
+				setFormat(config.Config.Format, &currentFormat)
 			}
 		} else {
 			secretValue, err := vaultClient.ReadSecret(fmt.Sprintf("%s", a))
@@ -106,7 +111,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 		}
 	}
 
-	finalResult = append(finalResult, Outputs{Format: config.Config.Format, Filename: "", Result: result})
+	finalResult = append(finalResult, Outputs{Format: currentFormat, Filename: "", Result: result})
 	return finalResult, nil
 }
 
@@ -122,5 +127,12 @@ func setUpper(potentialUpper *bool, currentUpper *bool) {
 		*currentUpper = *potentialUpper
 	} else {
 		*currentUpper = config.Config.UpperCase
+	}
+}
+func setFormat(potentialFormat string, currentFormat *string) {
+	if potentialFormat != "" {
+		*currentFormat = potentialFormat
+	} else {
+		*currentFormat = config.Config.Format
 	}
 }

--- a/vault/extractSecrets.go
+++ b/vault/extractSecrets.go
@@ -40,9 +40,8 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON) ([]Outputs, error)
 			for c, d := range aa {
 				setPrefix(d.Prefix, &currentPrefix)
 				setUpper(d.UpperCase, &currentUpperCase)
-				setFormat(d.Format, &currentFormat)
 
-				if currentFormat != "" {
+				if d.Format != "" {
 					secretValue, err := vaultClient.ReadSecret(fmt.Sprintf("%s", c))
 					if err != nil {
 						return nil, err


### PR DESCRIPTION
Thus fixes a bug where the secrets weren't exported properly, thereby rendering `dump-secrets-yaml` useless.