### PR TITLE
ES-2023 Upgrade CronJob apiVersion

### DIFF
--- a/orb/CronJob.yml
+++ b/orb/CronJob.yml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: $APP_NAME
@@ -12,7 +12,7 @@ spec:
             - name: secret-dumper
               image: harbor.bestsellerit.com/library/harpocrates:$HARPOCRATES_VERSION
               args:
-                - '$SECRETS'
+                - "$SECRETS"
               volumeMounts:
                 - name: secrets
                   mountPath: /secrets
@@ -26,7 +26,6 @@ spec:
               securityContext:
                 privileged: false
                 allowPrivilegeEscalation: false
-
 
           containers:
             - name: $CONTAINER_NAME


### PR DESCRIPTION
As of Kubernetes version 1.21 the official CronJob apiVersion is `batch/v1`.

This is a ⚠️ **breaking change** ⚠️. You must run Kubernetes 1.21 when this change is introduced to Harpocrates and released. 