### PR TITLE
fix for cronjob kustomize merge in kubectl 1.22

### DIFF
--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -311,5 +311,18 @@ commands:
             envsubst < ./$DEPLOYMENT_TYPE.yml > ./$DEPLOYMENT_TYPE\_var.yml
             mv ./$DEPLOYMENT_TYPE\_var.yml ./$DEPLOYMENT_TYPE.yml
 
-            kubectl kustomize . > new.yml
+            # workaround due to: https://github.com/kubernetes-sigs/kustomize/issues/4062
+            KUBE_VERSION=$(kubectl version -o yaml | yq .clientVersion.minor)
+            DEPLOYMENT_TYPE=CronJob
+            if [[ $KUBE_VERSION == 22 && $DEPLOYMENT_TYPE == "CronJob" ]]; then
+              curl -s https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.5.5/kustomize_v4.5.5_linux_arm64.tar.gz
+              tar -zxf kustomize_v4.5.5_linux_arm64.tar.gz
+              chmod +x kustomize
+
+              ./kustomize . > new.yml
+            fi
+              kubectl kustomize . > new.yml
+            fi
+
             mv new.yml $DEPLOY_FILE
+


### PR DESCRIPTION
I dont like this one, but it does create a workaround for the cronjob issues in kubectl 1.22