### PR TITLE
Append feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ yaml is a great options for readability and replication of configs. yaml options
 | owner     | no       | UID of the user e.g 0, can be set on "root" and secret level | current user |
 | prefix    | no       | prefix, can be set on any level                              | -            |
 | uppercase | no       | will uppercase prefix and key                                | false        |
+| append    | no       | appends secrets to a file                                    | true         |
 | secrets   | yes      | an array of secret paths                                     | -            |
 
 <br/>
@@ -156,6 +157,7 @@ There is not the same granularity as in the json and yaml specs. e.g. prefix can
 | prefix        | -                    | prefix keys, eg. K8S_                                                                                      |                          -                          |
 | uppercase     | -                    | will uppercase prefix and key                                                                              |                        false                        |
 | secret        | -                    | vault path /secretengine/data/some/secret                                                                  |                          -                          |
+| append        | -                    | Appends secrets to a file                                                                                  |                        true                         |
 | -             | HARPOCRATES_FILENAME | overwrites the default output filename                                                                     |                          -                          |
 
 

--- a/config/config.go
+++ b/config/config.go
@@ -10,19 +10,20 @@ import (
 
 // GlobalConfig defines the structure of the global configuration parameters
 type GlobalConfig struct {
-	VaultAddress string `required:"false"`
+	Append       bool   `required:"false"`
 	AuthName     string `required:"false"`
+	FileName     string `required:"false"`
+	Format       string `required:"false"`
+	LogLevel     string `required:"false"`
+	Output       string `required:"false"`
+	Owner        int    `required:"false"`
+	Prefix       string `required:"false"`
 	RoleName     string `required:"false"`
 	TokenPath    string `required:"false"`
-	VaultToken   string `required:"false"`
-	Prefix       string `required:"false"`
 	UpperCase    bool   `required:"false"`
-	Format       string `required:"false"`
-	Output       string `required:"false"`
-	FileName     string `required:"false"`
-	Owner        int    `required:"false"`
-	LogLevel     string `required:"false"`
 	Validate     bool   `required:"false"`
+	VaultAddress string `required:"false"`
+	VaultToken   string `required:"false"`
 }
 
 // Config stores the Global Configuration.

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -36,6 +36,10 @@ jobs:
         type: string
         default: ""
         description: Prefix to be used for secrets
+      append:
+        type: bool
+        default: true
+        description: Append, appends secrets to a file, defaults to true 
     steps:
       - attach_workspace:
           at: /tmp
@@ -62,6 +66,7 @@ jobs:
                 /harpocrates \
                   --format "<< parameters.format >>" \
                   --output "<< parameters.output >>" \
+                  --append "<< parameters.append >>" \
                   --prefix $prefix \
                   --secret $HARPOCRATES_SECRETS
               fi
@@ -72,6 +77,7 @@ jobs:
                 /harpocrates \
                   --format json \
                   --output "<< parameters.output >>" \
+                  --append "<< parameters.append >>" \
                   --secret "$CLUSTER_SECRET"
                 unset HARPOCRATES_FILENAME
               fi
@@ -87,6 +93,7 @@ jobs:
               /harpocrates \
                 --format "<< parameters.format >>" \
                 --output "<< parameters.output >>" \
+                --append "<< parameters.append >>" \
                 --prefix "<< parameters.prefix >>" \
                 --secret "<< parameters.vault-path >>" 
             fi

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -66,7 +66,7 @@ jobs:
                 /harpocrates \
                   --format "<< parameters.format >>" \
                   --output "<< parameters.output >>" \
-                  --append "<< parameters.append >>" \
+                  --append << parameters.append >> \
                   --prefix $prefix \
                   --secret $HARPOCRATES_SECRETS
               fi
@@ -77,7 +77,7 @@ jobs:
                 /harpocrates \
                   --format json \
                   --output "<< parameters.output >>" \
-                  --append "<< parameters.append >>" \
+                  --append << parameters.append >> \
                   --secret "$CLUSTER_SECRET"
                 unset HARPOCRATES_FILENAME
               fi
@@ -93,7 +93,7 @@ jobs:
               /harpocrates \
                 --format "<< parameters.format >>" \
                 --output "<< parameters.output >>" \
-                --append "<< parameters.append >>" \
+                --append << parameters.append >> \
                 --prefix "<< parameters.prefix >>" \
                 --secret "<< parameters.vault-path >>" 
             fi

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -37,7 +37,7 @@ jobs:
         default: ""
         description: Prefix to be used for secrets
       append:
-        type: bool
+        type: boolean
         default: true
         description: Append, appends secrets to a file, defaults to true 
     steps:

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -66,7 +66,7 @@ jobs:
                 /harpocrates \
                   --format "<< parameters.format >>" \
                   --output "<< parameters.output >>" \
-                  --append << parameters.append >> \
+                  --append=<< parameters.append >> \
                   --prefix $prefix \
                   --secret $HARPOCRATES_SECRETS
               fi
@@ -77,7 +77,7 @@ jobs:
                 /harpocrates \
                   --format json \
                   --output "<< parameters.output >>" \
-                  --append << parameters.append >> \
+                  --append=<< parameters.append >> \
                   --secret "$CLUSTER_SECRET"
                 unset HARPOCRATES_FILENAME
               fi
@@ -93,7 +93,7 @@ jobs:
               /harpocrates \
                 --format "<< parameters.format >>" \
                 --output "<< parameters.output >>" \
-                --append << parameters.append >> \
+                --append=<< parameters.append >> \
                 --prefix "<< parameters.prefix >>" \
                 --secret "<< parameters.vault-path >>" 
             fi

--- a/util/readInput.go
+++ b/util/readInput.go
@@ -11,6 +11,7 @@ import (
 
 // SecretJSON holds the information about which secrets to fetch and how to save them again
 type SecretJSON struct {
+	Append    *bool         `json:"append,omitempty"      yaml:"append,omitempty"`
 	Format    string        `json:"format,omitempty"      yaml:"format,omitempty"`
 	Output    string        `json:"output,omitempty"      yaml:"output,omitempty"`
 	Owner     *int          `json:"owner,omitempty"       yaml:"owner,omitempty"`
@@ -20,6 +21,7 @@ type SecretJSON struct {
 }
 
 type Secret struct {
+	Append    *bool         `json:"append,omitempty"      yaml:"append,omitempty"`
 	Prefix    string        `json:"prefix,omitempty"      yaml:"prefix,omitempty"`
 	Format    string        `json:"format,omitempty"      yaml:"format,omitempty"      mapstructure:"format,omitempty"`
 	FileName  string        `json:"filename,omitempty"    yaml:"filename,omitempty"    mapstructure:"filename,omitempty"`
@@ -29,6 +31,7 @@ type Secret struct {
 }
 
 type SecretKeys struct {
+	Append     *bool  `json:"append,omitempty"         yaml:"append,omitempty"`
 	Prefix     string `json:"prefix,omitempty"         yaml:"prefix,omitempty"      mapstructure:"prefix,omitempty"`
 	UpperCase  *bool  `json:"uppercase,omitempty"      yaml:"uppercase,omitempty"   mapstructure:"uppercase,omitempty"`
 	SaveAsFile *bool  `json:"saveAsFile,omitempty"     yaml:"saveAsFile,omitempty"`
@@ -78,6 +81,10 @@ MoveOn:
 
 	if secretJSON.UpperCase != nil {
 		config.Config.UpperCase = *secretJSON.UpperCase
+	}
+
+	if secretJSON.Append != nil {
+		config.Config.Append = *secretJSON.Append
 	}
 
 	return secretJSON

--- a/validate/schema.json
+++ b/validate/schema.json
@@ -3,6 +3,9 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
+    "append": {
+      "type": "boolean"
+    },
     "format": {
       "type": "string",
       "enum": [
@@ -53,6 +56,9 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
+            "append": {
+              "type": "boolean"
+            },
             "format": {
               "type": "string",
               "enum": [
@@ -90,6 +96,9 @@
                         "type": "object",
                         "additionalProperties": false,
                         "properties": {
+                          "append": {
+                            "type": "boolean"
+                          },
                           "prefix": {
                             "type": "string"
                           },


### PR DESCRIPTION
Added the ability to use the append feature that was already implemented in the continuous feature.
It has been both as a parameter and to the yaml/json spec.

It should solve all those "clean secrets" ci jobs we see and hopefully make lives a bit easier for devs.

testing:
Tested the orb on a repo where i go "append=false"
Tested locally the continuous feature with success (it does not append).
Tested the spec feature locally, with and without append in the spec with success.

