### PR TITLE
Bugfix: Glibc fix for Go 1.20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,19 +22,19 @@ jobs:
       - run:
           name: go build - windows/amd64
           command: |
-            GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o harpocrates.exe
+            CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o harpocrates.exe
             tar -czvf /tmp/harpocrates_$CIRCLE_TAG\_windows_amd64.tar.gz harpocrates.exe
             rm harpocrates.exe
       - run:
           name: go build - darwin/amd64
           command: |
-            GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o harpocrates
+            CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o harpocrates
             tar -czvf /tmp/harpocrates_$CIRCLE_TAG\_darwin_amd64.tar.gz harpocrates
             rm harpocrates
       - run:
           name: go build - linux/amd64
           command: |
-            GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o harpocrates
+            CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o harpocrates
             tar -czvf /tmp/harpocrates_$CIRCLE_TAG\_linux_amd64.tar.gz harpocrates
             mv harpocrates /tmp
       - persist_to_workspace:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.20.0-alpine AS builder
 WORKDIR $GOPATH/src/harpocrates
 COPY . .
-RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o /tmp/harpocrates
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o /tmp/harpocrates
 
 FROM alpine
 RUN apk add --no-cache bash

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,7 +1,7 @@
 FROM golang:1.20.0-alpine AS builder
 WORKDIR $GOPATH/src/harpocrates
 COPY . .
-RUN GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o /tmp/harpocrates
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -ldflags="-w -s" -o /tmp/harpocrates
 
 FROM alpine
 RUN apk add --no-cache bash gettext


### PR DESCRIPTION
Setting CGO to 0 to build a binary that doesn't depend on glibc at all.

It happens when we are building our app with a newer glibc then the system it runs on. Or that is how i understand it. But setting it to zero removes that dependency.
