### PR TITLE
Bumping cli tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
             source $BASH_ENV || true
             source /tmp/secrets || true
 
-            CCI_VERSION=0.1.22924
+            CCI_VERSION=0.1.30995
             wget https://github.com/CircleCI-Public/circleci-cli/releases/download/v$CCI_VERSION/circleci-cli_$CCI_VERSION\_linux_amd64.tar.gz
             tar -xf circleci-cli_$CCI_VERSION\_linux_amd64.tar.gz
             mv circleci-cli_$CCI_VERSION\_linux_amd64 cli

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
           password: $DOCKERHUB_PASS
 
 orbs:
-  secret-injector: bestsellerit/secret-injector@2.8.0
+  secret-injector: bestsellerit/secret-injector@2.8.1
   cci-common: bestsellerit/cci-common@3.6.1
 
 jobs:
@@ -152,8 +152,9 @@ common_context: &common_context
 workflows:
   test:
     jobs:
-      - secret-injector/dump-secrets:
+      - secret-injector/dump-secrets-yaml:
           name: secrets-common
+          secret-file: ci-secrets.yaml
           vault-oidc: true
           <<: [*common_context, *test_filter]
       - cci-common/go_test_unit:
@@ -198,12 +199,13 @@ workflows:
   test-build-release:
     jobs:
       - secret-injector/dump-secrets-yaml:
+          name: secrets-common
           secret-file: ci-secrets.yaml
           vault-oidc: true
           <<: [*common_context, *release_filter]
       - build-go:
           requires:
-            - secret-injector/dump-secrets-yaml
+            - secrets-common
           <<: [*common_context, *release_filter]
       - cci-common/build_n_push_docker:
           name: docker-build-n-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,13 +197,12 @@ workflows:
   test-build-release:
     jobs:
       - secret-injector/dump-secrets-yaml:
-          name: secrets-common
           secret-file: ci-secrets.yaml
           vault-oidc: true
           <<: [*common_context, *release_filter]
       - build-go:
           requires:
-            - secrets-common
+            - secret-injector/dump-secrets-yaml
           <<: [*common_context, *release_filter]
       - cci-common/build_n_push_docker:
           name: docker-build-n-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
           password: $DOCKERHUB_PASS
 
 orbs:
-  secret-injector: bestsellerit/secret-injector@2.8.1
+  secret-injector: bestsellerit/secret-injector@2.8.0
   cci-common: bestsellerit/cci-common@3.6.1
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,13 +158,11 @@ workflows:
           vault-oidc: true
           <<: [*common_context, *test_filter]
       - cci-common/go_test_unit:
-          go_version: "1.22.0"
           resource_class: xlarge
           requires:
             - secrets-common
           <<: [*common_context, *test_filter]
       - cci-common/go_test_sonar:
-          go_version: "1.22.0"
           resource_class: xlarge
           requires:
             - secrets-common

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -1,9 +1,6 @@
 version: 2.1
 description: Secret-injector orb
 
-orbs:
-  cci-common: bestsellerit/cci-common@3.6.1
-
 executors:
   secret_image:
     docker:
@@ -268,6 +265,47 @@ commands:
               $SUDO unzip -o ./vault_$VERSION\_linux_amd64.zip -d /usr/bin/. && \
               $SUDO chmod +x /usr/bin/./vault
               $SUDO rm ./vault_$VERSION\_linux_amd64.zip; }
+  python_install:
+    steps:
+      - run:
+          name: Install Python
+          command: |
+            if cat /etc/issue | grep Alpine > /dev/null 2>&1; then
+              echo "Checking For python3: Alpine"
+              ( command -v python3 && command -v pip ) >/dev/null 2>&1 || { apk add --no-cache python3 py3-pip; }
+            elif cat /etc/issue | grep Debian > /dev/null 2>&1 || cat /etc/issue | grep Ubuntu > /dev/null 2>&1; then
+              echo "Checking For python3: Debian"
+              if [ "$(id -u)" = 0 ]; then export SUDO=""; else # Check if we're root
+                export SUDO="sudo";
+              fi
+              ( command -v python3 && command -v pip ) || $SUDO apt -qq update && $SUDO apt -qq install -y python3 python3-pip;
+            fi
+  curl_install:
+    steps:
+      - run:
+          name: Install curl
+          command: |
+            if cat /etc/issue | grep Alpine > /dev/null 2>&1; then
+              echo "Checking For curl: Alpine"
+              command -v curl >/dev/null 2>&1 || { apk add --no-cache curl; }
+            elif cat /etc/issue | grep Debian > /dev/null 2>&1 || cat /etc/issue | grep Ubuntu > /dev/null 2>&1; then
+              echo "Checking For curl: Debian"
+              if [ "$(id -u)" = 0 ]; then export SUDO=""; else # Check if we're root
+                export SUDO="sudo";
+              fi
+              command -v curl >/dev/null 2>&1 || { $SUDO apt -qq update && $SUDO apt -qq install -y curl; }
+            fi
+  gcloud_install:
+    steps:
+      - run:
+          name: Install gcloud
+          command: |
+            source $BASH_ENV || true
+            GCLOUD_VERSION=422.0.0
+            command -v gcloud >/dev/null 2>&1 || { curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz --output "$HOME"/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz && \
+            tar -zxf "$HOME"/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz -C "$HOME" && \
+            "$HOME"/google-cloud-sdk/install.sh -q --command-completion true --path-update true; }
+            echo 'export PATH="$HOME"/google-cloud-sdk/bin/:${PATH}' >> "$BASH_ENV"
 
   vault-login:
     steps:
@@ -300,7 +338,9 @@ commands:
         default: $VAULT_USERNAME
 
     steps:
-      - cci-common/install_gcloud
+      - python_install
+      - curl_install
+      - gcloud_install
       - run:
           name: Generate credential configuration for CircleCI OIDC Token
           command: |

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -253,7 +253,7 @@ commands:
           command: |
             source $BASH_ENV || true
 
-            VERSION=v4.25.2
+            VERSION=v4.44.3
             command -v yq >/dev/null 2>&1 || { $SUDO wget -O /usr/bin/yq https://github.com/mikefarah/yq/releases/download/$VERSION/yq_linux_amd64 && \
               $SUDO chmod +x /usr/bin/yq; }
   vault_install:

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -263,7 +263,7 @@ commands:
           command: |
             source $BASH_ENV || true
 
-            VERSION=1.12.1
+            VERSION=1.18.1
             command -v vault >/dev/null 2>&1 || { $SUDO wget -O ./vault_$VERSION\_linux_amd64.zip https://releases.hashicorp.com/vault/$VERSION/vault_$VERSION\_linux_amd64.zip && \
               $SUDO unzip -o ./vault_$VERSION\_linux_amd64.zip -d /usr/bin/. && \
               $SUDO chmod +x /usr/bin/./vault

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -316,17 +316,6 @@ commands:
             "$HOME"/google-cloud-sdk/install.sh -q --command-completion true --path-update true; }
             echo 'export PATH="$HOME"/google-cloud-sdk/bin/:${PATH}' >> "$BASH_ENV"
 
-  vault-login:
-    steps:
-      - vault_install
-      - run:
-          name: Secret-injector - Vault login
-          command: |
-            source $BASH_ENV || true
-
-            vault login -no-print -method=userpass username=$VAULT_USERNAME password=$VAULT_PASSWORD
-            echo 'export VAULT_TOKEN=$(cat $HOME/.vault-token)' >> $BASH_ENV
-
   vault_login_oidc:
     description: Login in to Vault using OIDC
     parameters:

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -310,7 +310,7 @@ commands:
           name: Install gcloud
           command: |
             source $BASH_ENV || true
-            GCLOUD_VERSION=422.0.0
+            GCLOUD_VERSION=500.0.0
             command -v gcloud >/dev/null 2>&1 || { curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz --output "$HOME"/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz && \
             tar -zxf "$HOME"/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz -C "$HOME" && \
             "$HOME"/google-cloud-sdk/install.sh -q --command-completion true --path-update true; }

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -277,52 +277,6 @@ commands:
             vault login -no-print -method=userpass username=$VAULT_USERNAME password=$VAULT_PASSWORD
             echo 'export VAULT_TOKEN=$(cat $HOME/.vault-token)' >> $BASH_ENV
 
-  python_install:
-    steps:
-      - run:
-          name: Install Python
-          command: |
-            if cat /etc/issue | grep Alpine > /dev/null 2>&1; then
-              echo "Checking For python3: Alpine"
-              ( command -v python3 && command -v pip ) >/dev/null 2>&1 || { apk add --no-cache python3 py3-pip; }
-            elif cat /etc/issue | grep Debian > /dev/null 2>&1 || cat /etc/issue | grep Ubuntu > /dev/null 2>&1; then
-              echo "Checking For python3: Debian"
-              if [ "$(id -u)" = 0 ]; then export SUDO=""; else # Check if we're root
-                export SUDO="sudo";
-              fi
-              ( command -v python3 && command -v pip ) || $SUDO apt -qq update && $SUDO apt -qq install -y python3 python3-pip;
-            fi
-
-  curl_install:
-    steps:
-      - run:
-          name: Install curl
-          command: |
-            if cat /etc/issue | grep Alpine > /dev/null 2>&1; then
-              echo "Checking For curl: Alpine"
-              command -v curl >/dev/null 2>&1 || { apk add --no-cache curl; }
-            elif cat /etc/issue | grep Debian > /dev/null 2>&1 || cat /etc/issue | grep Ubuntu > /dev/null 2>&1; then
-              echo "Checking For curl: Debian"
-              if [ "$(id -u)" = 0 ]; then export SUDO=""; else # Check if we're root
-                export SUDO="sudo";
-              fi
-              command -v curl >/dev/null 2>&1 || { $SUDO apt -qq update && $SUDO apt -qq install -y curl; }
-            fi
-
-  gcloud_install:
-    steps:
-      - run:
-          name: Install gcloud
-          command: |
-            source $BASH_ENV || true
-
-            GCLOUD_VERSION=422.0.0
-            command -v gcloud >/dev/null 2>&1 || { curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz --output "$HOME"/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz && \
-            tar -zxf "$HOME"/google-cloud-sdk-"$GCLOUD_VERSION"-linux-x86_64.tar.gz -C "$HOME" && \
-            "$HOME"/google-cloud-sdk/install.sh -q --command-completion true --path-update true; }
-
-            echo 'export PATH="$HOME"/google-cloud-sdk/bin/:${PATH}' >> "$BASH_ENV"
-
   vault_login_oidc:
     description: Login in to Vault using OIDC
     parameters:
@@ -343,13 +297,10 @@ commands:
         default: $VAULT_USERNAME
 
     steps:
-      - python_install
-      - curl_install
-      - gcloud_install
+      - cci-common/install_gcloud
       - run:
           name: Generate credential configuration for CircleCI OIDC Token
           command: |
-
             echo $CIRCLE_OIDC_TOKEN > << parameters.oidc_token_file_path >>
 
             # Create a credential configuration for the generated OIDC ID Token
@@ -361,7 +312,6 @@ commands:
       - run:
           name: Gcloud login using credential configuration
           command: |
-
             gcloud auth login --brief --cred-file "<< parameters.gcp_cred_config_file_path >>"
 
             echo "export GOOGLE_APPLICATION_CREDENTIALS='<< parameters.gcp_cred_config_file_path >>'" | tee -a $BASH_ENV

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -265,6 +265,15 @@ commands:
               $SUDO unzip -o ./vault_$VERSION\_linux_amd64.zip -d /usr/bin/. && \
               $SUDO chmod +x /usr/bin/./vault
               $SUDO rm ./vault_$VERSION\_linux_amd64.zip; }
+  vault-login:
+    steps:
+      - vault_install
+      - run:
+          name: Secret-injector - Vault login
+          command: |
+            source $BASH_ENV || true
+            vault login -no-print -method=userpass username=$VAULT_USERNAME password=$VAULT_PASSWORD
+            echo 'export VAULT_TOKEN=$(cat $HOME/.vault-token)' >> $BASH_ENV
   python_install:
     steps:
       - run:

--- a/orb/orb.yml
+++ b/orb/orb.yml
@@ -1,6 +1,9 @@
 version: 2.1
 description: Secret-injector orb
 
+orbs:
+  cci-common: bestsellerit/cci-common@3.6.1
+
 executors:
   secret_image:
     docker:


### PR DESCRIPTION
This pull request includes updates to the CircleCI configuration and the orb configuration files to use newer versions of various tools and improve the secret injection process.

### CircleCI Configuration Updates:
* Updated `CCI_VERSION` to `0.1.30995` in `.circleci/config.yml`
* Changed job `secret-injector/dump-secrets` to `secret-injector/dump-secrets-yaml` and added `secret-file` parameter

### Orb Configuration Updates:
* Updated `yq` version to `v4.44.3` in `orb/orb.yml`
* Updated `vault` version to `1.18.1` in `orb/orb.yml`
* Updated `gcloud` version to `500.0.0` in `orb/orb.yml`

This will hopefully fix these errors:
- https://app.circleci.com/pipelines/github/BESTSELLER/cluster-registry/1976/workflows/799fa023-e3ff-459f-bebe-0f0795a2bc00/jobs/4076
- https://app.circleci.com/pipelines/github/BESTSELLER/backstage-homepage/520/workflows/25006cef-4a53-4730-a23d-9a9df0e643ca/jobs/926
