### PR TITLE
Potential fix for code scanning alert no. 28: Writable file handle closed without error handling

### DIFF
--- a/files/files.go
+++ b/files/files.go
@@ -46,7 +46,11 @@ func Write(output string, fileName string, content interface{}, owner *int, appe
 		os.Exit(1)
 	}
 
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Error().Err(err).Msgf("Failed to close file '%s'", path)
+		}
+	}()
 
 	if _, err = f.WriteString(fmt.Sprintf("%v", content)); err != nil {
 		log.Fatal().Err(err).Msgf("Unable to write to file '%s'", path)


### PR DESCRIPTION
Potential fix for [https://github.com/BESTSELLER/harpocrates/security/code-scanning/28](https://github.com/BESTSELLER/harpocrates/security/code-scanning/28)

To fix the issue, we need to ensure that any errors returned by `f.Close()` are explicitly handled. This can be achieved by using a deferred function that checks the return value of `f.Close()` and logs an error if it occurs. The deferred function should also ensure that it does not overwrite any existing errors (e.g., from the `f.WriteString` call).

The changes will be made in the `Write` function in `files/files.go`. Specifically:
1. Replace the `defer f.Close()` statement with a deferred function that checks and handles errors from `f.Close()`.
2. Ensure that the deferred function does not overwrite any existing errors.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
