### PR TITLE
Rename non-descriptive variables for improved readability + changed from `json.NewEncoder` to `json.Marshal`

### DIFF
--- a/cmd/do.go
+++ b/cmd/do.go
@@ -59,14 +59,14 @@ func doIt(cmd *cobra.Command, args []string) []string {
 			return secretEnvs
 		}
 
-		y := make([]interface{}, len(*secret))
+		secretItems := make([]interface{}, len(*secret))
 
-		for i, s := range *secret {
-			y[i] = s
+		for i, secretPath := range *secret {
+			secretItems[i] = secretPath
 		}
 
 		input = util.SecretJSON{
-			Secrets: y,
+			Secrets: secretItems,
 		}
 	} else {
 		if len(args) == 0 {
@@ -97,22 +97,22 @@ func doIt(cmd *cobra.Command, args []string) []string {
 		return secretEnvs
 	}
 
-	for _, v := range allSecrets {
+	for _, output := range allSecrets {
 		fileName := config.Config.FileName
-		if v.Filename != "" {
-			fileName = v.Filename
+		if output.Filename != "" {
+			fileName = output.Filename
 		}
 
-		switch v.Format {
+		switch output.Format {
 		case "json":
-			files.Write(config.Config.Output, fileName, v.Result.ToJSON(), v.Owner, config.Config.Append)
+			files.Write(config.Config.Output, fileName, output.Result.ToJSON(), output.Owner, config.Config.Append)
 		case "env":
-			files.Write(config.Config.Output, fileName, v.Result.ToENV(), v.Owner, config.Config.Append)
-			secretEnvs = append(secretEnvs, v.Result.ToKVarray("")...)
+			files.Write(config.Config.Output, fileName, output.Result.ToENV(), output.Owner, config.Config.Append)
+			secretEnvs = append(secretEnvs, output.Result.ToKVarray("")...)
 		case "secret":
-			files.Write(config.Config.Output, fileName, v.Result.ToK8sSecret(), v.Owner, config.Config.Append)
+			files.Write(config.Config.Output, fileName, output.Result.ToK8sSecret(), output.Owner, config.Config.Append)
 		case "yaml":
-			files.Write(config.Config.Output, fileName, v.Result.ToYAML(), v.Owner, config.Config.Append)
+			files.Write(config.Config.Output, fileName, output.Result.ToYAML(), output.Owner, config.Config.Append)
 		}
 		log.Debug().Msgf("Secrets written to file: %s/%s", config.Config.Output, fileName)
 	}

--- a/vault/alias_test.go
+++ b/vault/alias_test.go
@@ -38,9 +38,9 @@ func TestExtractSecretsWithAlias(t *testing.T) {
 	}
 
 	// assert
-	for _, v := range result {
+	for _, output := range result {
 		// Assert newKey1 is present and key1 is not (or rather key1 is mapped to value1 but key in result is newKey1)
-		resMap := v.Result
+		resMap := output.Result
 		if val, ok := resMap["newKey1"]; !ok {
 			t.Errorf("Expected 'newKey1' in result, got %v", resMap)
 		} else if val != "value1" {
@@ -135,8 +135,8 @@ func TestExtractSecretsWithKeyLevelUpperCase(t *testing.T) {
 	}
 
 	// assert: key1 has uppercase: true at the key level, so it should be uppercased to KEY1
-	for _, v := range result {
-		resMap := v.Result
+	for _, output := range result {
+		resMap := output.Result
 		if val, ok := resMap["KEY1"]; !ok {
 			t.Errorf("Expected 'KEY1' (uppercased) in result, got %v", resMap)
 		} else if val != "value1" {
@@ -200,8 +200,8 @@ func TestExtractSecretsWithAliasNested(t *testing.T) {
 	}
 
 	// assert
-	for _, v := range result {
-		resMap := v.Result
+	for _, output := range result {
+		resMap := output.Result
 		if val, ok := resMap["myTopSecret"]; !ok {
 			t.Errorf("Expected 'myTopSecret' in result, got %v", resMap)
 		} else if val != "HelloThere!" {

--- a/vault/extractSecrets.go
+++ b/vault/extractSecrets.go
@@ -26,97 +26,97 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 	var currentUpperCase = config.Config.UpperCase
 	var currentFormat = config.Config.Format
 
-	for _, a := range input.Secrets {
+	for _, secretEntry := range input.Secrets {
 
 		// If the key is just a secret path, then it will read that from Vault, otherwise:
-		if _, isString := a.(string); !isString {
-			b, ok := a.(map[string]interface{})
+		if _, isString := secretEntry.(string); !isString {
+			secretMapRaw, ok := secretEntry.(map[string]interface{})
 			if !ok {
-				return nil, fmt.Errorf("expected map[string]interface{}, got: '%s'", a)
+				return nil, fmt.Errorf("expected map[string]interface{}, got: '%s'", secretEntry)
 			}
 
-			aa := map[string]util.Secret{}
-			err := mapstructure.Decode(b, &aa)
+			secretConfigMap := map[string]util.Secret{}
+			err := mapstructure.Decode(secretMapRaw, &secretConfigMap)
 			if err != nil {
 				return finalResult, err
 			}
 
-			for c, d := range aa {
-				setPrefix(d.Prefix, &currentPrefix)
-				setUpper(d.UpperCase, &currentUpperCase)
-				setFormat(d.Format, &currentFormat)
+			for secretPath, secretConfig := range secretConfigMap {
+				setPrefix(secretConfig.Prefix, &currentPrefix)
+				setUpper(secretConfig.UpperCase, &currentUpperCase)
+				setFormat(secretConfig.Format, &currentFormat)
 
-				if len(d.Keys) == 0 {
-					secretValue, err := vaultClient.ReadSecret(c)
+				if len(secretConfig.Keys) == 0 {
+					secretValue, err := vaultClient.ReadSecret(secretPath)
 					if err != nil {
 						return nil, err
 					}
 					var thisResult = make(secrets.Result)
-					for k, v := range secretValue {
-						thisResult.Add(k, v, currentPrefix, currentUpperCase)
+					for key, value := range secretValue {
+						thisResult.Add(key, value, currentPrefix, currentUpperCase)
 					}
 
-					finalResult = append(finalResult, Outputs{Format: currentFormat, Filename: d.FileName, Result: thisResult, Owner: d.Owner})
+					finalResult = append(finalResult, Outputs{Format: currentFormat, Filename: secretConfig.FileName, Result: thisResult, Owner: secretConfig.Owner})
 					continue
 				}
 
-				for _, f := range d.Keys {
+				for _, keyEntry := range secretConfig.Keys {
 					// If the key is just a secret path, then it will read that from Vault, otherwise:
-					if _, isString := f.(string); !isString {
-						bb := map[string]util.SecretKeys{}
-						err := mapstructure.Decode(f, &bb)
+					if _, isString := keyEntry.(string); !isString {
+						secretKeysConfigMap := map[string]util.SecretKeys{}
+						err := mapstructure.Decode(keyEntry, &secretKeysConfigMap)
 						if err != nil {
 							return finalResult, err
 						}
 
-						for h, i := range bb {
-							setPrefix(i.Prefix, &currentPrefix)
-							setUpper(i.UpperCase, &currentUpperCase)
+						for vaultKey, keyConfig := range secretKeysConfigMap {
+							setPrefix(keyConfig.Prefix, &currentPrefix)
+							setUpper(keyConfig.UpperCase, &currentUpperCase)
 
-							keyName := h
-							if i.Alias != "" {
-								keyName = i.Alias
+							keyName := vaultKey
+							if keyConfig.Alias != "" {
+								keyName = keyConfig.Alias
 							}
 
-							if i.SaveAsFile != nil {
-								secretValue, err := vaultClient.ReadSecretKey(c, h)
+							if keyConfig.SaveAsFile != nil {
+								secretValue, err := vaultClient.ReadSecretKey(secretPath, vaultKey)
 								if err != nil {
 									return nil, err
 								}
-								if *i.SaveAsFile {
+								if *keyConfig.SaveAsFile {
 									files.Write(input.Output, secrets.ToUpperOrNotToUpper(fmt.Sprintf("%s%s", currentPrefix, keyName), &currentUpperCase), secretValue, nil, appendToFile)
 								} else {
 									result.Add(keyName, secretValue, currentPrefix, currentUpperCase)
 								}
 							} else {
-								secretValue, err := vaultClient.ReadSecretKey(c, h)
+								secretValue, err := vaultClient.ReadSecretKey(secretPath, vaultKey)
 								if err != nil {
 									return nil, err
 								}
 								result.Add(keyName, secretValue, currentPrefix, currentUpperCase)
 							}
-							setPrefix(d.Prefix, &currentPrefix)
-							setUpper(d.UpperCase, &currentUpperCase)
+							setPrefix(secretConfig.Prefix, &currentPrefix)
+							setUpper(secretConfig.UpperCase, &currentUpperCase)
 						}
 					} else {
-						secretValue, err := vaultClient.ReadSecretKey(c, fmt.Sprintf("%s", f))
+						secretValue, err := vaultClient.ReadSecretKey(secretPath, fmt.Sprintf("%s", keyEntry))
 						if err != nil {
 							return nil, err
 						}
-						result.Add(fmt.Sprintf("%s", f), secretValue, currentPrefix, currentUpperCase)
+						result.Add(fmt.Sprintf("%s", keyEntry), secretValue, currentPrefix, currentUpperCase)
 					}
 				}
 				setPrefix(config.Config.Prefix, &currentPrefix)
-				setUpper(d.UpperCase, &currentUpperCase)
-				setFormat(d.Format, &currentFormat)
+				setUpper(secretConfig.UpperCase, &currentUpperCase)
+				setFormat(secretConfig.Format, &currentFormat)
 			}
 		} else {
-			secretValue, err := vaultClient.ReadSecret(fmt.Sprintf("%s", a))
+			secretValue, err := vaultClient.ReadSecret(fmt.Sprintf("%s", secretEntry))
 			if err != nil {
 				return nil, err
 			}
-			for aa, bb := range secretValue {
-				result.Add(aa, bb, currentPrefix, currentUpperCase)
+			for key, value := range secretValue {
+				result.Add(key, value, currentPrefix, currentUpperCase)
 			}
 		}
 	}

--- a/vault/extractSecrets_test.go
+++ b/vault/extractSecrets_test.go
@@ -81,11 +81,11 @@ func TestExtractSecretsWithFormatAsExpected(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	for _, v := range result {
+	for _, output := range result {
 
 		// assert
 		expected := fmt.Sprintf("%v", map[string]interface{}{input.Prefix + "key1": "value1", input.Prefix + "key2": "value2", input.Prefix + "key3": "value3", input.Prefix + "key4": float64(123), input.Prefix + "key5": true})
-		actual := fmt.Sprintf("%v", v.Result)
+		actual := fmt.Sprintf("%v", output.Result)
 
 		if expected != actual {
 			t.Errorf("expected %q, got %q", expected, actual)
@@ -118,10 +118,10 @@ func TestExtractSecretsAsExpected(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	for _, v := range result {
+	for _, output := range result {
 		// assert
 		expected := fmt.Sprintf("%v", map[string]interface{}{input.Prefix + "key1": "value1", input.Prefix + "key2": "value2", input.Prefix + "key3": "value3", input.Prefix + "key4": float64(123), input.Prefix + "key5": true})
-		actual := fmt.Sprintf("%v", v.Result)
+		actual := fmt.Sprintf("%v", output.Result)
 
 		if expected != actual {
 			t.Errorf("expected %q, got %q", expected, actual)
@@ -155,10 +155,10 @@ func TestExtractSecretsWithPrefixAsExpected(t *testing.T) {
 		t.Error(err)
 	}
 
-	for _, v := range result {
+	for _, output := range result {
 		// assert
 		expected := fmt.Sprintf("%v", map[string]interface{}{"PRE_key1": "value1", "FIX_key2": "value2", input.Prefix + "key3": "value3"})
-		actual := fmt.Sprintf("%v", v.Result)
+		actual := fmt.Sprintf("%v", output.Result)
 
 		if expected != actual {
 			t.Errorf("expected %q, got %q", expected, actual)

--- a/vault/login.go
+++ b/vault/login.go
@@ -36,13 +36,12 @@ func Login() {
 
 	url := config.Config.VaultAddress + "/v1/auth/" + config.Config.AuthName + "/login"
 
-	buf := new(bytes.Buffer)
-	err := json.NewEncoder(buf).Encode(JWTPayLoad{Jwt: token.Read(), Role: config.Config.RoleName})
+	payload, err := json.Marshal(JWTPayLoad{Jwt: token.Read(), Role: config.Config.RoleName})
 	if err != nil {
 		log.Fatal().Err(err).Msg("Unable to prepare jwt token")
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, buf)
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
 		log.Fatal().Err(err).Msg("Unable to create login request to Vault")
 	}

--- a/vault/login.go
+++ b/vault/login.go
@@ -36,13 +36,13 @@ func Login() {
 
 	url := config.Config.VaultAddress + "/v1/auth/" + config.Config.AuthName + "/login"
 
-	b := new(bytes.Buffer)
-	err := json.NewEncoder(b).Encode(JWTPayLoad{Jwt: token.Read(), Role: config.Config.RoleName})
+	buf := new(bytes.Buffer)
+	err := json.NewEncoder(buf).Encode(JWTPayLoad{Jwt: token.Read(), Role: config.Config.RoleName})
 	if err != nil {
 		log.Fatal().Err(err).Msg("Unable to prepare jwt token")
 	}
 
-	req, err := http.NewRequest(http.MethodPost, url, b)
+	req, err := http.NewRequest(http.MethodPost, url, buf)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Unable to create login request to Vault")
 	}


### PR DESCRIPTION
Renamed single-letter and double-letter variable names throughout the codebase to clearly communicate intent.

The reason for the change from `json.NewEncoder` to `json.Marshal` is purely a theoretical performance improvement, since the struct we are doing it on is so small. The difference might just be in nanoseconds, but every little bit counts.
In short, `json.NewEncoder` is built for streaming that whereas `json.Marshal` is designed to be used for to convert an in-memory object into JSON meaning this change should be a tiny bit faster.

