### PR TITLE
Validate Vault token and fail early

### DIFF
--- a/cmd/do.go
+++ b/cmd/do.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -14,28 +15,37 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func loadLocalVaultToken() {
+func loadLocalVaultToken() error {
+	if config.Config.VaultToken == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			log.Debug().Err(err).Msg("unable to get home directory")
+		} else {
+			vaultTokenFile := path.Join(homeDir, ".vault-token")
+			token, err := os.ReadFile(vaultTokenFile)
+			if err == nil {
+				config.Config.VaultToken = strings.TrimSpace(string(token))
+				log.Debug().Msg("using vault token from ~/.vault-token")
+			}
+		}
+	}
+
 	if config.Config.VaultToken != "" {
-		return
+		client := vault.NewClient()
+		_, err := client.Client.Auth().Token().LookupSelf()
+		if err != nil {
+			return fmt.Errorf("vault token is invalid or expired: %w", err)
+		}
 	}
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		log.Debug().Err(err).Msg("unable to get home directory")
-		return
-	}
-
-	vaultTokenFile := path.Join(homeDir, ".vault-token")
-	token, err := os.ReadFile(vaultTokenFile)
-	if err == nil {
-		config.Config.VaultToken = strings.TrimSpace(string(token))
-		log.Debug().Msg("using vault token from ~/.vault-token")
-	}
-
+	return nil
 }
 
 func doIt(cmd *cobra.Command, args []string) []string {
-	loadLocalVaultToken()
+	err := loadLocalVaultToken()
+	if err != nil {
+		log.Fatal().Err(err).Msg("vault token validation failed")
+	}
 
 	secretEnvs := []string{}
 

--- a/cmd/do.go
+++ b/cmd/do.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -15,37 +14,28 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func loadLocalVaultToken() error {
-	if config.Config.VaultToken == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			log.Debug().Err(err).Msg("unable to get home directory")
-		} else {
-			vaultTokenFile := path.Join(homeDir, ".vault-token")
-			token, err := os.ReadFile(vaultTokenFile)
-			if err == nil {
-				config.Config.VaultToken = strings.TrimSpace(string(token))
-				log.Debug().Msg("using vault token from ~/.vault-token")
-			}
-		}
-	}
-
+func loadLocalVaultToken() {
 	if config.Config.VaultToken != "" {
-		client := vault.NewClient()
-		_, err := client.Client.Auth().Token().LookupSelf()
-		if err != nil {
-			return fmt.Errorf("vault token is invalid or expired: %w", err)
-		}
+		return
 	}
 
-	return nil
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Debug().Err(err).Msg("unable to get home directory")
+		return
+	}
+
+	vaultTokenFile := path.Join(homeDir, ".vault-token")
+	token, err := os.ReadFile(vaultTokenFile)
+	if err == nil {
+		config.Config.VaultToken = strings.TrimSpace(string(token))
+		log.Debug().Msg("using vault token from ~/.vault-token")
+	}
+
 }
 
 func doIt(cmd *cobra.Command, args []string) []string {
-	err := loadLocalVaultToken()
-	if err != nil {
-		log.Fatal().Err(err).Msg("vault token validation failed")
-	}
+	loadLocalVaultToken()
 
 	secretEnvs := []string{}
 

--- a/cmd/do.go
+++ b/cmd/do.go
@@ -82,7 +82,10 @@ func doIt(cmd *cobra.Command, args []string) []string {
 		}
 	}
 
-	vault.Login()
+	err := vault.Login()
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to login to Vault")
+	}
 
 	vaultClient := vault.NewClient()
 

--- a/vault/login.go
+++ b/vault/login.go
@@ -19,13 +19,13 @@ type JWTPayLoad struct {
 }
 
 // Login will exchange the JWT token for a Vault token
-func Login() {
+func Login() error {
 	// If a token exists, validate it. If valid, skip the login.
 	if config.Config.VaultToken != "" {
 		client := NewClient()
 		_, err := client.Client.Auth().Token().LookupSelf()
 		if err == nil {
-			return
+			return nil
 		}
 		log.Warn().Err(err).Msg("Vault token is invalid or expired, falling back to other authentication methods")
 		config.Config.VaultToken = ""
@@ -34,39 +34,40 @@ func Login() {
 	if config.Config.GcpWorkloadID {
 		login, err := gcp.FetchVaultLogin(config.Config.VaultAddress, config.Config.AuthName)
 		if err != nil {
-			log.Fatal().Err(err).Msg("GcpWorkload Identity was enabled but auth failed")
+			return fmt.Errorf("GcpWorkload Identity was enabled but auth failed: %w", err)
 		}
 		config.Config.VaultToken = login.Auth.ClientToken
-		return
+		return nil
 	}
 
 	url := config.Config.VaultAddress + "/v1/auth/" + config.Config.AuthName + "/login"
 
 	payload, err := json.Marshal(JWTPayLoad{Jwt: token.Read(), Role: config.Config.RoleName})
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to prepare jwt token")
+		return fmt.Errorf("unable to prepare jwt token: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to create login request to Vault")
+		return fmt.Errorf("unable to create login request to Vault: %w", err)
 	}
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unable to make login call to Vault")
+		return fmt.Errorf("unable to make login call to Vault: %w", err)
 	}
 	defer res.Body.Close() //nolint:errcheck // We don't care about errors from this
 
 	returnPayload := gcp.VaultLoginResult{}
 	err = json.NewDecoder(res.Body).Decode(&returnPayload)
 	if err != nil {
-		log.Fatal().Err(err).Msg("Unexpected response from Vault")
+		return fmt.Errorf("unexpected response from Vault: %w", err)
 	}
 
 	if len(returnPayload.Errors) != 0 {
-		log.Fatal().Err(fmt.Errorf("%s", returnPayload.Errors)).Msg("API call to Vault failed")
+		return fmt.Errorf("API call to Vault failed: %s", returnPayload.Errors)
 	}
 
 	config.Config.VaultToken = returnPayload.Auth.ClientToken
+	return nil
 }

--- a/vault/login.go
+++ b/vault/login.go
@@ -20,9 +20,15 @@ type JWTPayLoad struct {
 
 // Login will exchange the JWT token for a Vault token
 func Login() {
-	// If a token exists, skip the login.
+	// If a token exists, validate it. If valid, skip the login.
 	if config.Config.VaultToken != "" {
-		return
+		client := NewClient()
+		_, err := client.Client.Auth().Token().LookupSelf()
+		if err == nil {
+			return
+		}
+		log.Warn().Err(err).Msg("Vault token is invalid or expired, falling back to other authentication methods")
+		config.Config.VaultToken = ""
 	}
 
 	if config.Config.GcpWorkloadID {


### PR DESCRIPTION
This PR enhances the Vault login workflow by validating existing Vault tokens before attempting to use them. 

Previously, if `config.Config.VaultToken` was present, the authentication step was entirely skipped, which could lead to subsequent failures if the token was expired or invalid. 

Now, if a token is provided, `harpocrates` will actively validate it using the `LookupSelf()` endpoint. If the token is valid, it proceeds as normal. If the token is invalid or expired, a warning is logged, the token is cleared, and it safely falls back to configuring other authentication methods (e.g., GCP Workload Identity / Kubernetes Auth).

## Changes Made
- Added a validation check (`LookupSelf()`) for existing Vault tokens in `vault/login.go`.
- Added fallback logic to clear the invalid token and proceed to other authentication methods if the token is rejected.
- Added a warning log to notify the user when an existing token format fails validation or is expired.

## Motivation and Context
This prevents arbitrary failures downstream when `harpocrates` is run with a stale token, making the authentication experience much more resilient.