### PR TITLE
Pin Vault container version to 1.21 in unit test

### DIFF
--- a/vault/extractSecrets_test.go
+++ b/vault/extractSecrets_test.go
@@ -19,7 +19,7 @@ func setupVault(t *testing.T) {
 	ctx := context.Background()
 
 	vaultContainer, err := vault.Run(ctx,
-		"hashicorp/vault:latest",
+		"hashicorp/vault:1.21",
 		vault.WithToken("unittesttoken"),
 	)
 	if err != nil {


### PR DESCRIPTION
I'm doing this right now, due to the breaking changes in Vault 2.0.0 - we of course need to update this version later, I'm hoping dependabot can update this for us.