### PR TITLE
Pin GoReleaser version and enable Renovate updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,5 +33,6 @@ jobs:
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
           distribution: goreleaser
-          version: "~> v2"
+          # renovate: datasource=github-releases depName=goreleaser/goreleaser
+          version: "v2.15.4"
           args: release --clean --snapshot --skip=sign

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,5 +34,5 @@ jobs:
         with:
           distribution: goreleaser
           # renovate: datasource=github-releases depName=goreleaser/goreleaser
-          version: "v2.15.4"
+          version: "v2.15.3"
           args: release --clean --snapshot --skip=sign

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,8 @@ jobs:
         uses: goreleaser/goreleaser-action@e24998b8b67b290c2fa8b7c14fcfa7de2c5c9b8c # v7.1.0
         with:
           distribution: goreleaser
-          version: "~> v2"
+          # renovate: datasource=github-releases depName=goreleaser/goreleaser
+          version: "v2.15.4"
           args: release --clean
         env:
           # A GitHub App token is used here because pushing to other repositories

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
         with:
           distribution: goreleaser
           # renovate: datasource=github-releases depName=goreleaser/goreleaser
-          version: "v2.15.4"
+          version: "v2.15.3"
           args: release --clean
         env:
           # A GitHub App token is used here because pushing to other repositories

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,13 @@
       "matchStrings": [
         "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n.+?\\n\\s*\"[^:\"]+:(?<currentValue>[^\"]+)\""
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/.*\\.yml$"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\n\\s+version: [\"']?(?<currentValue>[^\"'\\n]+)[\"']?"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR transitions the GoReleaser action across our GitHub Actions workflows from using loose version bounds (`~> v2`) to an exact pinned version (`v2.15.3`). To ensure this version remains up to date, it also configures Renovate to automatically manage future version bumps.

> [!IMPORTANT]
> I chose not to use the latest version so that we can verify that renovate works as intended.

## Changes

* Pinned version within the `goreleaser/goreleaser-action` steps and added inline comments for Renovate.
* Updated renovate.json to include these comments in its update cycles.

## Why

Using exact version pinning ensures completely deterministic builds and releases. By pairing exact pins with Renovate automation, we achieve the stability of locked versions while still receiving automated dependency bump pull requests.

