### PR TITLE
`files.Read()` now returns an error instead of doing a `log.Fatal()`

### DIFF
--- a/cmd/do.go
+++ b/cmd/do.go
@@ -43,7 +43,12 @@ func doIt(cmd *cobra.Command, args []string) []string {
 	var input util.SecretJSON
 
 	if secretFile != "" {
-		data = files.Read(secretFile)
+		var err error
+		data, err = files.Read(secretFile)
+		if err != nil {
+			log.Fatal().Err(err).Msgf("Unable to read the file at path '%s'", secretFile)
+		}
+
 		validFile := validate.SecretsFile(data)
 		if !validFile {
 			log.Fatal().Msg("Invalid file")

--- a/files/files.go
+++ b/files/files.go
@@ -13,13 +13,13 @@ import (
 var fileNameRegexp = regexp.MustCompile("[^a-zA-Z0-9.-]+")
 
 // Read will read the content of a file and return it as a string.
-func Read(filePath string) string {
+func Read(filePath string) (string, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
-		log.Fatal().Err(err).Msgf("Unable to read the file at path '%s'", filePath)
+		return "", fmt.Errorf("unable to read the file at path '%s': %w", filePath, err)
 	}
 
-	return fmt.Sprint(string(data))
+	return fmt.Sprint(string(data)), nil
 }
 
 // Write will write some string data to a file

--- a/token/token.go
+++ b/token/token.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Read will read a file and return the content as string
-func Read() string {
+func Read() (string, error) {
 	// Defaults to Kubernetes Service Account
 	filePath := "/var/run/secrets/kubernetes.io/serviceaccount/token"
 

--- a/validate/secretsFile_test.go
+++ b/validate/secretsFile_test.go
@@ -34,7 +34,10 @@ func TestSecretsFile(t *testing.T) {
 	tests := collectTests()
 	for _, test := range tests {
 		log.Debug().Msgf("Testing file: %s\n", test)
-		file := files.Read(test)
+		file, err := files.Read(test)
+		if err != nil {
+			t.Fatalf("Failed to read file %s: %v", test, err)
+		}
 		switch strings.Contains(test, "not_valid") {
 		case true:
 			if SecretsFile(file) {

--- a/vault/alias_test.go
+++ b/vault/alias_test.go
@@ -17,7 +17,10 @@ func TestExtractSecretsWithAlias(t *testing.T) {
 	})
 
 	// define input
-	data := files.Read("../test_data/key_alias.yaml")
+	data, err := files.Read("../test_data/key_alias.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix
@@ -68,7 +71,10 @@ func TestExtractSecretsWithAliasAndSaveAsFile(t *testing.T) {
 	})
 
 	// define input
-	data := files.Read("../test_data/key_alias_save_as_file.yaml")
+	data, err := files.Read("../test_data/key_alias_save_as_file.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix
@@ -83,7 +89,7 @@ func TestExtractSecretsWithAliasAndSaveAsFile(t *testing.T) {
 	defer os.Remove("../.tmp/TEST_key1")    //nolint:errcheck // It's just tests, we don't care
 
 	// act
-	_, err := vaultClient.ExtractSecrets(input, false)
+	_, err = vaultClient.ExtractSecrets(input, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -114,7 +120,10 @@ func TestExtractSecretsWithKeyLevelUpperCase(t *testing.T) {
 	})
 
 	// define input
-	data := files.Read("../test_data/key_alias_uppercase.yaml")
+	data, err := files.Read("../test_data/key_alias_uppercase.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix
@@ -179,7 +188,10 @@ func TestExtractSecretsWithAliasNested(t *testing.T) {
 	}
 
 	// define input
-	data := files.Read("../test_data/key_alias_nested.yaml")
+	data, err := files.Read("../test_data/key_alias_nested.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix

--- a/vault/extractSecrets_test.go
+++ b/vault/extractSecrets_test.go
@@ -67,7 +67,10 @@ func TestExtractSecretsWithFormatAsExpected(t *testing.T) {
 	})
 
 	// define input
-	data := files.Read("../test_data/two_secrets_with_format.yaml")
+	data, err := files.Read("../test_data/two_secrets_with_format.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix
@@ -104,7 +107,10 @@ func TestExtractSecretsAsExpected(t *testing.T) {
 	})
 
 	// define input
-	data := files.Read("../test_data/single_secret.yaml")
+	data, err := files.Read("../test_data/single_secret.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix
@@ -140,7 +146,10 @@ func TestExtractSecretsWithPrefixAsExpected(t *testing.T) {
 	})
 
 	// define input
-	data := files.Read("../test_data/keys_with_prefix.yaml")
+	data, err := files.Read("../test_data/keys_with_prefix.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix
@@ -177,7 +186,10 @@ func TestExtractSecretsSaveAsFileAsExpected(t *testing.T) {
 	})
 
 	// define input
-	data := files.Read("../test_data/save_as_file.yaml")
+	data, err := files.Read("../test_data/save_as_file.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
 	input := util.ReadInput(data)
 
 	// mock prefix
@@ -188,7 +200,7 @@ func TestExtractSecretsSaveAsFileAsExpected(t *testing.T) {
 	}
 
 	// act
-	_, err := vaultClient.ExtractSecrets(input, false)
+	_, err = vaultClient.ExtractSecrets(input, false)
 	if err != nil {
 		t.Error(err)
 	}

--- a/vault/login.go
+++ b/vault/login.go
@@ -42,7 +42,12 @@ func Login() error {
 
 	url := config.Config.VaultAddress + "/v1/auth/" + config.Config.AuthName + "/login"
 
-	payload, err := json.Marshal(JWTPayLoad{Jwt: token.Read(), Role: config.Config.RoleName})
+	jwtToken, err := token.Read()
+	if err != nil {
+		return fmt.Errorf("unable to read token: %w", err)
+	}
+
+	payload, err := json.Marshal(JWTPayLoad{Jwt: jwtToken, Role: config.Config.RoleName})
 	if err != nil {
 		return fmt.Errorf("unable to prepare jwt token: %w", err)
 	}


### PR DESCRIPTION
This is preparation for future work I am doing - and I like to not exit the program within some function and instead return that error and handle it where it is being called instead.