### PR TITLE
Switching from generating completions manually and instead use the new `generate_completions_from_executable`

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,10 +64,15 @@ homebrew_casks:
       owner: BESTSELLER
       name: homebrew-tap
     description: "Harpocrates is a lightweight, versatile CLI tool designed to securely fetch, format, and inject secrets from HashiCorp Vault"
-    completions:
-      bash: completions/harpocrates.bash
-      zsh: completions/harpocrates.zsh
-      fish: completions/harpocrates.fish
+    generate_completions_from_executable:
+      args:
+        - completion
+      shell_parameter_format: cobra
+      shells:
+        - bash
+        - zsh
+        - fish
+        - pwsh
 
 winget:
   - name: harpocrates

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,11 +3,6 @@ version: 2
 before:
   hooks:
     - go mod tidy
-    - mkdir -p completions
-    - sh -c "go run main.go completion bash > completions/harpocrates.bash"
-    - sh -c "go run main.go completion zsh > completions/harpocrates.zsh"
-    - sh -c "go run main.go completion fish > completions/harpocrates.fish"
-    - sh -c "go run main.go completion powershell > completions/harpocrates.ps1"
 
 builds:
   - env:
@@ -27,8 +22,6 @@ builds:
 
 archives:
   - # this name template makes the OS and Arch compatible with the results of `uname`.
-    files:
-      - completions/*
     name_template: >-
       {{ .ProjectName }}_
       {{- title .Os }}_


### PR DESCRIPTION
This will ensure the completion will get installed when you install the application with homebrew.