### PR TITLE
Using "pretty logging" for the `dev` command

### DIFF
--- a/cmd/dev.go
+++ b/cmd/dev.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BESTSELLER/harpocrates/config"
 	"github.com/BESTSELLER/harpocrates/util"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +26,8 @@ The dev command fetches secrets from Vault and makes them available to a child p
 It creates temporary files for the secrets and cleans them up after the command has finished executing.
 This is useful for local development, where you want to run an application with secrets from Vault without storing them in plaintext on your machine.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: zerolog.TimeFieldFormat})
+
 		if len(args) == 0 {
 			log.Fatal().Msg("No command provided to execute")
 		}
@@ -37,7 +40,7 @@ This is useful for local development, where you want to run an application with 
 
 		config.Config.Output = path.Join(dir, config.Config.Output)
 
-		fmt.Println("output:", config.Config.Output)
+		log.Info().Str("output", config.Config.Output).Send()
 
 		secretEnvs := doIt(cmd, args)
 
@@ -51,7 +54,6 @@ This is useful for local development, where you want to run an application with 
 			cancel()
 		}()
 
-		fmt.Println(config.Config.Output)
 		// Start the child application with the temporary file path using the context
 		var execCmd *exec.Cmd
 		if len(args) == 1 {


### PR DESCRIPTION
This is just to make a bit more pretty when running it locally with the `dev` command.

Before:
<img width="728" height="109" alt="image" src="https://github.com/user-attachments/assets/c2f42afb-bcb4-4e44-86a0-706d9d45fd6f" />

After:
<img width="866" height="80" alt="image" src="https://github.com/user-attachments/assets/fc5d2359-6584-4bd8-95d8-74097b6b9a10" />
