### PR TITLE
Mark secrets a `optional`

### DIFF
--- a/test_data/non_optional_secret.yaml
+++ b/test_data/non_optional_secret.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - secret/test2
+  - secret/secret:
+      optional: false
+      keys:
+        - key1

--- a/test_data/non_optional_secret_key.yaml
+++ b/test_data/non_optional_secret_key.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - secret/secret:
+      optional: false
+      keys:
+        - keyThatDoesNotExist
+        - key1

--- a/test_data/optional_secret.yaml
+++ b/test_data/optional_secret.yaml
@@ -1,0 +1,7 @@
+secrets:
+  - secret/test2:
+      optional: true
+  - secret/secret:
+      optional: false
+      keys:
+        - key1

--- a/test_data/optional_secret_key.yaml
+++ b/test_data/optional_secret_key.yaml
@@ -1,0 +1,7 @@
+secrets:
+  - secret/secret:
+      optional: false
+      keys:
+        - "keyThatDoesNotExist":
+            optional: true
+        - key1

--- a/test_data/optional_secret_key.yaml
+++ b/test_data/optional_secret_key.yaml
@@ -2,6 +2,6 @@ secrets:
   - secret/secret:
       optional: false
       keys:
-        - "keyThatDoesNotExist":
+        - keyThatDoesNotExist:
             optional: true
         - key1

--- a/test_data/optional_secret_plain_key.yaml
+++ b/test_data/optional_secret_plain_key.yaml
@@ -1,0 +1,6 @@
+secrets:
+  - secret/secret:
+      optional: true
+      keys:
+        - keyThatDoesNotExist
+        - key1

--- a/util/readInput.go
+++ b/util/readInput.go
@@ -28,6 +28,7 @@ type Secret struct {
 	Format    string `json:"format,omitempty"      yaml:"format,omitempty"      mapstructure:"format,omitempty"`
 	FileName  string `json:"filename,omitempty"    yaml:"filename,omitempty"    mapstructure:"filename,omitempty"`
 	UpperCase *bool  `json:"uppercase,omitempty"   yaml:"uppercase,omitempty"`
+	Optional  *bool  `json:"optional,omitempty"    yaml:"optional,omitempty"    mapstructure:"optional,omitempty"`
 	Keys      []any  `json:"keys,omitempty"        yaml:"keys,omitempty"`
 	Owner     *int   `json:"owner,omitempty"       yaml:"owner,omitempty"`
 }
@@ -37,6 +38,7 @@ type SecretKeys struct {
 	Append     *bool  `json:"append,omitempty"         yaml:"append,omitempty"`
 	Prefix     string `json:"prefix,omitempty"         yaml:"prefix,omitempty"      mapstructure:"prefix,omitempty"`
 	UpperCase  *bool  `json:"uppercase,omitempty"      yaml:"uppercase,omitempty"   mapstructure:"uppercase,omitempty"`
+	Optional   *bool  `json:"optional,omitempty"       yaml:"optional,omitempty"    mapstructure:"optional,omitempty"`
 	SaveAsFile *bool  `json:"saveAsFile,omitempty"     yaml:"saveAsFile,omitempty"`
 	Alias      string `json:"alias,omitempty"          yaml:"alias,omitempty"       mapstructure:"alias,omitempty"`
 }

--- a/validate/schema.json
+++ b/validate/schema.json
@@ -82,6 +82,10 @@
               "type": "boolean",
               "description": "Whether to save this secret as a file."
             },
+            "optional": {
+              "type": "boolean",
+              "description": "Whether to ignore it and continue if the secret doesn't exist."
+            },
             "fileName": {
               "type": "string",
               "description": "An alias for filename."
@@ -116,6 +120,10 @@
                           "alias": {
                             "type": "string",
                             "description": "An alias to rename this key in the output."
+                          },
+                          "optional": {
+                            "type": "boolean",
+                            "description": "Whether to ignore it and continue if the key doesn't exist."
                           },
                           "uppercase": {
                             "type": "boolean",

--- a/vault/extractSecrets.go
+++ b/vault/extractSecrets.go
@@ -86,7 +86,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 							if keyConfig.SaveAsFile != nil {
 								secretValue, err := vaultClient.ReadSecretKey(secretPath, vaultKey)
 								if err != nil {
-									if keyConfig.Optional != nil && *keyConfig.Optional {
+									if *keyConfig.Optional {
 										log.Info().Msgf("Optional secret key '%s' not found in '%s', skipping.", vaultKey, secretPath)
 										continue
 									}
@@ -100,7 +100,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 							} else {
 								secretValue, err := vaultClient.ReadSecretKey(secretPath, vaultKey)
 								if err != nil {
-									if keyConfig.Optional != nil && *keyConfig.Optional {
+									if *keyConfig.Optional {
 										log.Info().Msgf("Optional secret key '%s' not found in '%s', skipping.", vaultKey, secretPath)
 										continue
 									}
@@ -114,7 +114,7 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 					} else {
 						secretValue, err := vaultClient.ReadSecretKey(secretPath, fmt.Sprintf("%s", keyEntry))
 						if err != nil {
-							if secretConfig.Optional != nil && *secretConfig.Optional {
+							if *secretConfig.Optional {
 								log.Info().Msgf("Optional secret key '%s' not found in '%s', skipping.", keyEntry, secretPath)
 								continue
 							}

--- a/vault/extractSecrets.go
+++ b/vault/extractSecrets.go
@@ -8,6 +8,7 @@ import (
 	"github.com/BESTSELLER/harpocrates/secrets"
 	"github.com/BESTSELLER/harpocrates/util"
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/rs/zerolog/log"
 )
 
 // Outputs represents the output format for secrets
@@ -49,6 +50,10 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 				if len(secretConfig.Keys) == 0 {
 					secretValue, err := vaultClient.ReadSecret(secretPath)
 					if err != nil {
+						if secretConfig.Optional != nil && *secretConfig.Optional {
+							log.Info().Msgf("Optional secret '%s' not found, skipping.", secretPath)
+							continue
+						}
 						return nil, err
 					}
 					var thisResult = make(secrets.Result)
@@ -81,6 +86,10 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 							if keyConfig.SaveAsFile != nil {
 								secretValue, err := vaultClient.ReadSecretKey(secretPath, vaultKey)
 								if err != nil {
+									if keyConfig.Optional != nil && *keyConfig.Optional {
+										log.Info().Msgf("Optional secret key '%s' not found in '%s', skipping.", vaultKey, secretPath)
+										continue
+									}
 									return nil, err
 								}
 								if *keyConfig.SaveAsFile {
@@ -91,6 +100,10 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 							} else {
 								secretValue, err := vaultClient.ReadSecretKey(secretPath, vaultKey)
 								if err != nil {
+									if keyConfig.Optional != nil && *keyConfig.Optional {
+										log.Info().Msgf("Optional secret key '%s' not found in '%s', skipping.", vaultKey, secretPath)
+										continue
+									}
 									return nil, err
 								}
 								result.Add(keyName, secretValue, currentPrefix, currentUpperCase)
@@ -101,6 +114,10 @@ func (vaultClient *API) ExtractSecrets(input util.SecretJSON, appendToFile bool)
 					} else {
 						secretValue, err := vaultClient.ReadSecretKey(secretPath, fmt.Sprintf("%s", keyEntry))
 						if err != nil {
+							if secretConfig.Optional != nil && *secretConfig.Optional {
+								log.Info().Msgf("Optional secret key '%s' not found in '%s', skipping.", keyEntry, secretPath)
+								continue
+							}
 							return nil, err
 						}
 						result.Add(fmt.Sprintf("%s", keyEntry), secretValue, currentPrefix, currentUpperCase)

--- a/vault/extractSecrets_test.go
+++ b/vault/extractSecrets_test.go
@@ -58,6 +58,145 @@ func setupVault(t *testing.T) {
 	testClient = client
 }
 
+// TestExtractSecretsWithOptionalSecret verifies that a missing optional secret is skipped without error
+func TestExtractSecretsWithOptionalSecret(t *testing.T) {
+	// arrange
+	setupVault(t)
+	t.Cleanup(func() {
+		testClient = nil
+	})
+
+	// define input
+	data, err := files.Read("../test_data/optional_secret.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
+	input := util.ReadInput(data)
+
+	// mock prefix
+	config.Config.Prefix = input.Prefix
+
+	vaultClient := &API{
+		Client: testClient,
+	}
+
+	// act
+	result, err := vaultClient.ExtractSecrets(input, false)
+
+	// assert
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should still extract the key1 from secret/secret
+	expectedSize := 1
+	if len(result[0].Result) != expectedSize {
+		t.Errorf("Expected %d secret, got %d", expectedSize, len(result[0].Result))
+	}
+}
+
+// TestExtractSecretsWithOptionalSecretKey verifies that a missing optional secret key is skipped without error
+func TestExtractSecretsWithOptionalSecretKey(t *testing.T) {
+	// arrange
+	setupVault(t)
+	t.Cleanup(func() {
+		testClient = nil
+	})
+
+	// define input
+	data, err := files.Read("../test_data/optional_secret_key.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
+	input := util.ReadInput(data)
+
+	// mock prefix
+	config.Config.Prefix = input.Prefix
+
+	vaultClient := &API{
+		Client: testClient,
+	}
+
+	// act
+	result, err := vaultClient.ExtractSecrets(input, false)
+
+	// assert
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should still extract key1
+	expectedSize := 1
+	if len(result[0].Result) != expectedSize {
+		t.Errorf("Expected %d secret, got %d", expectedSize, len(result[0].Result))
+	}
+}
+
+// TestExtractSecretsWithOptionalSecretPlainKey verifies that a missing plain key inside an optional secret is skipped
+func TestExtractSecretsWithOptionalSecretPlainKey(t *testing.T) {
+	// arrange
+	setupVault(t)
+	t.Cleanup(func() {
+		testClient = nil
+	})
+
+	// define input
+	data, err := files.Read("../test_data/optional_secret_plain_key.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
+	input := util.ReadInput(data)
+
+	// mock prefix
+	config.Config.Prefix = input.Prefix
+
+	vaultClient := &API{
+		Client: testClient,
+	}
+
+	// act
+	result, err := vaultClient.ExtractSecrets(input, false)
+
+	// assert
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	// Should still extract key1
+	expectedSize := 1
+	if len(result[0].Result) != expectedSize {
+		t.Errorf("Expected %d secret, got %d", expectedSize, len(result[0].Result))
+	}
+}
+
+// TestExtractSecretsWithNonOptional verifies that a missing non-optional secret still fails
+func TestExtractSecretsWithNonOptional(t *testing.T) {
+	// arrange
+	setupVault(t)
+	t.Cleanup(func() {
+		testClient = nil
+	})
+
+	// define input
+	data, err := files.Read("../test_data/non_optional_secret.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read test data: %v", err)
+	}
+	input := util.ReadInput(data)
+
+	vaultClient := &API{
+		Client: testClient,
+	}
+
+	// act
+	_, err = vaultClient.ExtractSecrets(input, false)
+
+	// assert
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+}
+
 // TestExtractSecretsWithFormatAsExpected tests if a two secrets one with a format is extracted correctly
 func TestExtractSecretsWithFormatAsExpected(t *testing.T) {
 	// arrange


### PR DESCRIPTION
Adds support for marking secrets and individual secret keys as optional in the extraction process. With these changes, missing optional secrets or keys will be skipped without causing errors, and the logic is thoroughly tested with new test cases. The schema, data structures, and extraction logic are all updated to handle the new `optional` flag.

These changes ensure greater flexibility and robustness in secret extraction workflows, especially in environments where some secrets or keys may be absent by design.

fixes #272