### PR TITLE
CI: `fetch-depth: 0` option in the `Checkout` workflow step is required for GoReleaser to work properly, as it will need the full history to work properly.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - name: Getting secrets
         id: secrets


### PR DESCRIPTION
Just following the documentation: https://goreleaser.com/customization/ci/actions/